### PR TITLE
Fix Parsing of /usage?format=json from luminous rados gw

### DIFF
--- a/radosgw_usage_exporter.py
+++ b/radosgw_usage_exporter.py
@@ -83,7 +83,10 @@ class RADOSGWCollector(object):
     def _process_data(self, entry):
         # Recieves JSON object 'entity' that contains all the buckets relating
         # to a given RGW UID.
-        bucket_owner = entry['owner']
+        try:
+          bucket_owner = entry['owner']
+        except: # Luminous 
+          bucket_owner = entry['user']
         for bucket in entry['buckets']:
             print bucket
             if not bucket['bucket']:

--- a/radosgw_usage_exporter.py
+++ b/radosgw_usage_exporter.py
@@ -83,9 +83,10 @@ class RADOSGWCollector(object):
     def _process_data(self, entry):
         # Recieves JSON object 'entity' that contains all the buckets relating
         # to a given RGW UID.
-        try:
+        if 'owner' in entry:
           bucket_owner = entry['owner']
-        except: # Luminous 
+        # Luminous 
+        elif 'user' in entry: # Luminous 
           bucket_owner = entry['user']
         for bucket in entry['buckets']:
             print bucket


### PR DESCRIPTION
Luminous format seems to be different from the previous versions and i needed this change to have json returned parsed properly.

I never run this on an older version though so i might be on a wrong track ? 

Example output from the "usage/format=json" follow 

```
{u'entries': [{u'buckets': [{u'bucket': u'',
                             u'categories': [{u'bytes_received': 0,
                                              u'bytes_sent': 1547434,
                                              u'category': u'list_buckets',
                                              u'ops': 7231,
                                              u'successful_ops': 7231}],
                             u'epoch': 1519048800,
                             u'owner': u'anonymous',
                             u'time': u'2018-02-19 14:00:00.000000Z'}],
               u'user': u'anonymous'},
              {u'buckets': [{u'bucket': u'',
                             u'categories': [{u'bytes_received': 0,
                                              u'bytes_sent': 326,
                                              u'category': u'list_buckets',
                                              u'ops': 1,
                                              u'successful_ops': 1}],
                             u'epoch': 1519048800,
                             u'owner': u'fc',
                             u'time': u'2018-02-19 14:00:00.000000Z'},
                            {u'bucket': u'FCTEST1',
                             u'categories': [{u'bytes_received': 0,
                                              u'bytes_sent': 3319,
                                              u'category': u'list_bucket',
                                              u'ops': 4,
                                              u'successful_ops': 4}],
                             u'epoch': 1519048800,
                             u'owner': u'fc',
                             u'time': u'2018-02-19 14:00:00.000000Z'}],
               u'user': u'fc'}]}
```