### PR TITLE
Adding error handling if ['usage']['rgw.main'] doesn't exist in bucket

### DIFF
--- a/radosgw_usage_exporter.py
+++ b/radosgw_usage_exporter.py
@@ -226,7 +226,7 @@ class RADOSGWCollector(object):
             bucket_utilized_bytes = 0
             bucket_usage_objects = 0
 
-            if bucket['usage']:
+            try:
                 # Prefer bytes, instead kbytes
                 if 'size_actual' in bucket['usage']['rgw.main']:
                     bucket_usage_bytes = bucket['usage']['rgw.main']['size_actual']
@@ -242,6 +242,10 @@ class RADOSGWCollector(object):
                 # Get number of objects in bucket
                 if 'num_objects' in bucket['usage']['rgw.main']:
                     bucket_usage_objects = bucket['usage']['rgw.main']['num_objects']
+            except KeyError:
+                bucket_usage_bytes = 0
+                bucket_utilized_bytes = 0
+                bucket_usage_objects = 0
 
 
             if 'zonegroup' in bucket:


### PR DESCRIPTION
A rudimentary fix to #15.

Adds error handling to proceed if the script encounters any buckets which do not have the key ['usage']['rgw.main']. Sets all values for that bucket to zero.