### PR TITLE
Solved Issue "KeyError: 'rgw.main'"

### DIFF
--- a/radosgw_usage_exporter.py
+++ b/radosgw_usage_exporter.py
@@ -76,7 +76,6 @@ class RADOSGWCollector(object):
         for metric in self._prometheus_metrics.values():
             yield metric
 
-
     def _request_data(self, query, args):
         """
         Requests data from RGW. If admin entry and caps is fine - return
@@ -228,21 +227,21 @@ class RADOSGWCollector(object):
 
             if bucket['usage']:
                 # Prefer bytes, instead kbytes
-                if 'size_actual' in bucket['usage']['rgw.main']:
-                    bucket_usage_bytes = bucket['usage']['rgw.main']['size_actual']
-                # Hammer don't have bytes field
-                elif 'size_kb_actual' in bucket['usage']['rgw.main']:
-                    usage_kb = bucket['usage']['rgw.main']['size_kb_actual']
-                    bucket_usage_bytes = usage_kb * 1024
+                if "rgw.main" in bucket['usage']:
+                    if 'size_actual' in bucket['usage']['rgw.main']:
+                        bucket_usage_bytes = bucket['usage']['rgw.main']['size_actual']
+                    # Hammer don't have bytes field
+                    elif 'size_kb_actual' in bucket['usage']['rgw.main']:
+                        usage_kb = bucket['usage']['rgw.main']['size_kb_actual']
+                        bucket_usage_bytes = usage_kb * 1024
 
-                # Compressed buckets, since Kraken
-                if 'size_utilized' in bucket['usage']['rgw.main']:
-                    bucket_utilized_bytes = bucket['usage']['rgw.main']['size_utilized']
+                    # Compressed buckets, since Kraken
+                    if 'size_utilized' in bucket['usage']['rgw.main']:
+                        bucket_utilized_bytes = bucket['usage']['rgw.main']['size_utilized']
 
-                # Get number of objects in bucket
-                if 'num_objects' in bucket['usage']['rgw.main']:
-                    bucket_usage_objects = bucket['usage']['rgw.main']['num_objects']
-
+                    # Get number of objects in bucket
+                    if 'num_objects' in bucket['usage']['rgw.main']:
+                        bucket_usage_objects = bucket['usage']['rgw.main']['num_objects']
 
             if 'zonegroup' in bucket:
                 bucket_zonegroup = bucket['zonegroup']


### PR DESCRIPTION
I was facing the following issue. After debugging, I found out that 'rgw.main' was missing in one "usage" form the bucket usage list.  So I have added the condition. Please verify and merge it so that we can use the exporter.
```
Traceback (most recent call last):
  File "./radosgw_usage_exporter.py", line 324, in <module>
    main()
  File "./radosgw_usage_exporter.py", line 313, in main
    args.host, args.admin_entry, args.access_key, args.secret_key))
  File "/usr/local/lib/python2.7/site-packages/prometheus_client/core.py", line 50, in register
    names = self._get_names(collector)
  File "/usr/local/lib/python2.7/site-packages/prometheus_client/core.py", line 86, in _get_names
    for metric in desc_func():
  File "./radosgw_usage_exporter.py", line 70, in collect
    self._get_bucket_usage(bucket)
  File "./radosgw_usage_exporter.py", line 231, in _get_bucket_usage
    if 'size_actual' in bucket['usage']['rgw.main']:
KeyError: 'rgw.main'
```