### PR TITLE
Fixed issue when bucket exists, but 'usage' is empty due RGW bug

### DIFF
--- a/radosgw_usage_exporter.py
+++ b/radosgw_usage_exporter.py
@@ -296,7 +296,7 @@ class RADOSGWCollector(object):
             bucket_utilized_bytes = 0
             bucket_usage_objects = 0
 
-            if bucket['usage']:
+            if bucket['usage'] and 'rgw.main' in bucket['usage']:
                 # Prefer bytes, instead kbytes
                 if 'size_actual' in bucket['usage']['rgw.main']:
                     bucket_usage_bytes = bucket['usage']['rgw.main']['size_actual']


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "./check_ceph_rgw_api", line 116, in <module>
    sys.exit(main())
  File "./check_ceph_rgw_api", line 95, in main
    bucket_usage_kb = usage_dict['rgw.main']['size_kb_actual']
KeyError: 'rgw.main'
```

This possible with old RGW's due multipart bugs, for example
this bucket impossible to delete, because multiparts objects
is not exits. So better just skip this bucket.

```json
{
    "object": "_multipart_obj_tag.txt.2~KFWA-rRXHsFLc45G3-rDFimIM4yD1aU.meta"
}
{
    "existing_header": {
        "usage": {
            "rgw.multimeta": {
                "size": 0,
                "size_actual": 0,
                "size_utilized": 0,
                "size_kb": 0,
                "size_kb_actual": 0,
                "size_kb_utilized": 0,
                "num_objects": 1
            }
        }
    },
    "calculated_header": {
        "usage": {
            "rgw.multimeta": {
                "size": 0,
                "size_actual": 0,
                "size_utilized": 0,
                "size_kb": 0,
                "size_kb_actual": 0,
                "size_kb_utilized": 0,
                "num_objects": 1
            }
        }
    }
}
```