### PR TITLE
fix(get_rgw_users): use metadata query for listing users (#48)

### DIFF
--- a/radosgw_usage_exporter.py
+++ b/radosgw_usage_exporter.py
@@ -430,17 +430,8 @@ class RADOSGWCollector(object):
         """
         API request to get users.
         """
-
-        rgw_users = self._request_data(query="user", args="list")
-
-        if rgw_users and "keys" in rgw_users:
-            return rgw_users["keys"]
-        else:
-            # Compat with old Ceph versions (pre 12.2.13/13.2.9)
-            rgw_metadata_users = self._request_data(query="metadata/user", args="")
-            return rgw_metadata_users
-
-        return
+        rgw_metadata_users = self._request_data(query="metadata/user", args="")
+        return rgw_metadata_users
 
     def _get_user_info(self, user):
         """


### PR DESCRIPTION
The `/admin/user?format=json&list` only output the first 1000 users that it come across. `/admin/metadata/user?format=json` will output all users.

The official Go library for Ceph still uses "metadata/user" for listing all users. (https://github.com/ceph/go-ceph/blob/master/rgw/admin/user.go#L136-L149)

This will fix issue #48 