### PR TITLE
Add ipv6 support

### DIFF
--- a/radosgw_usage_exporter.py
+++ b/radosgw_usage_exporter.py
@@ -595,7 +595,7 @@ def main():
                 args.timeout,
             )
         )
-        start_http_server(args.port)
+        start_http_server(args.port, addr="::")
         logging.info(("Polling {0}. Serving at port: {1}".format(args.host, args.port)))
         while True:
             time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-prometheus-client==0.18.0
-requests>=2.26.0
+prometheus-client==0.21.0
+requests==2.32.3
 boto==2.49.0
 requests-aws==0.1.8


### PR DESCRIPTION
By default, the exporter will only listen to IPv4. This PR add support for IPv6.
I also bumped the dependencies.